### PR TITLE
Add Sandbox catalog endpoint (GET /v1/sandboxes/catalog)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ with Sandbox.create(plan="small") as sb:
 sb = Sandbox.from_id("sb_...")
 etl_boxes = Sandbox.list(tags={"job": "etl-42"})
 
+# List available plans (id, vcpu, ram_gb, disk_gb, price_per_hour)
+for plan in Sandbox.catalog():
+    print(plan.id, plan.vcpu, plan.ram_gb, plan.price_per_hour)
+
 # Large scripts: upload, then run
 sb.fs.write("/work/script.py", open("script.py").read())
 sb.exec("python3", "/work/script.py", timeout="30m")

--- a/deepinfra/__init__.py
+++ b/deepinfra/__init__.py
@@ -21,7 +21,7 @@ from ._exceptions import (
     SandboxWaitError,
     TooManySandboxesError,
 )
-from ._sandbox_models import ExecResult, SandboxInfo
+from ._sandbox_models import ExecResult, SandboxInfo, SandboxPlan
 from ._version import __version__
 from .clients import DeepInfraClient, RequestSpec
 from .models import (
@@ -39,6 +39,7 @@ __all__ = [
     "Sandbox",
     "SandboxFS",
     "SandboxInfo",
+    "SandboxPlan",
     "ExecResult",
     # client
     "DeepInfraClient",

--- a/deepinfra/_sandbox_models.py
+++ b/deepinfra/_sandbox_models.py
@@ -19,6 +19,18 @@ class SandboxInfo(pydantic.BaseModel):
     model_config = pydantic.ConfigDict(extra="ignore")
 
 
+class SandboxPlan(pydantic.BaseModel):
+    """A plan offered by GET /v1/sandboxes/catalog."""
+
+    id: str
+    vcpu: int
+    ram_gb: int
+    disk_gb: int
+    price_per_hour: float
+
+    model_config = pydantic.ConfigDict(extra="ignore")
+
+
 class ExecResult(pydantic.BaseModel):
     """Aggregated result of a sandbox command."""
 

--- a/deepinfra/sandbox_api.py
+++ b/deepinfra/sandbox_api.py
@@ -22,7 +22,7 @@ from typing import Any, Union
 from urllib.parse import quote
 
 from ._exceptions import NotFoundError, SandboxFailedError, SandboxTimeoutError
-from ._sandbox_models import ExecResult, SandboxInfo
+from ._sandbox_models import ExecResult, SandboxInfo, SandboxPlan
 from ._streaming import afold_exec_events, aiter_ndjson, fold_exec_events, iter_ndjson
 from ._utils import backoff_delays, parse_duration, tags_match
 from .clients.deepinfra import DeepInfraClient, RequestSpec, default_client
@@ -172,6 +172,21 @@ class Sandbox:
         client = client or default_client()
         items = (await client.arequest(_list_spec())).json()
         return cls._from_list(items, tags, client)
+
+    @classmethod
+    def catalog(cls, *, client: DeepInfraClient | None = None) -> builtins.list[SandboxPlan]:
+        """List available sandbox plans with their specs and hourly pricing."""
+        client = client or default_client()
+        items = client.request(_catalog_spec()).json()
+        return [SandboxPlan.model_validate(item) for item in items]
+
+    @classmethod
+    async def acatalog(
+        cls, *, client: DeepInfraClient | None = None
+    ) -> builtins.list[SandboxPlan]:
+        client = client or default_client()
+        items = (await client.arequest(_catalog_spec())).json()
+        return [SandboxPlan.model_validate(item) for item in items]
 
     # -- lifecycle --
 
@@ -436,6 +451,10 @@ def _get_spec(sandbox_id: str) -> RequestSpec:
 
 def _list_spec() -> RequestSpec:
     return RequestSpec("GET", _SANDBOXES, retry_connect=True)
+
+
+def _catalog_spec() -> RequestSpec:
+    return RequestSpec("GET", f"{_SANDBOXES}/catalog", retry_connect=True)
 
 
 def _op_spec(sandbox_id: str, op: str) -> RequestSpec:

--- a/deepinfra/sandbox_api.py
+++ b/deepinfra/sandbox_api.py
@@ -174,7 +174,11 @@ class Sandbox:
         return cls._from_list(items, tags, client)
 
     @classmethod
-    def catalog(cls, *, client: DeepInfraClient | None = None) -> builtins.list[SandboxPlan]:
+    def catalog(
+        cls,
+        *, 
+        client: DeepInfraClient | None = None,
+    ) -> builtins.list[SandboxPlan]:
         """List available sandbox plans with their specs and hourly pricing."""
         client = client or default_client()
         items = client.request(_catalog_spec()).json()
@@ -182,7 +186,9 @@ class Sandbox:
 
     @classmethod
     async def acatalog(
-        cls, *, client: DeepInfraClient | None = None
+        cls, 
+        *, 
+        client: DeepInfraClient | None = None,
     ) -> builtins.list[SandboxPlan]:
         client = client or default_client()
         items = (await client.arequest(_catalog_spec())).json()

--- a/deepinfra/sandbox_api.py
+++ b/deepinfra/sandbox_api.py
@@ -176,7 +176,7 @@ class Sandbox:
     @classmethod
     def catalog(
         cls,
-        *, 
+        *,
         client: DeepInfraClient | None = None,
     ) -> builtins.list[SandboxPlan]:
         """List available sandbox plans with their specs and hourly pricing."""
@@ -186,8 +186,8 @@ class Sandbox:
 
     @classmethod
     async def acatalog(
-        cls, 
-        *, 
+        cls,
+        *,
         client: DeepInfraClient | None = None,
     ) -> builtins.list[SandboxPlan]:
         client = client or default_client()

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -227,6 +227,28 @@ async def test_async_lifecycle(client):
 
 
 @respx.mock
+def test_catalog(client):
+    plans = [
+        {"id": "nano", "vcpu": 1, "ram_gb": 1, "disk_gb": 10, "price_per_hour": 0.01},
+        {"id": "medium", "vcpu": 4, "ram_gb": 8, "disk_gb": 40, "price_per_hour": 0.08},
+    ]
+    get = respx.get(f"{BASE_URL}/v1/sandboxes/catalog").respond(json=plans)
+    result = Sandbox.catalog(client=client)
+    assert get.call_count == 1
+    assert [p.id for p in result] == ["nano", "medium"]
+    assert result[0].vcpu == 1
+    assert result[1].price_per_hour == 0.08
+
+
+@respx.mock
+async def test_acatalog(client):
+    plans = [{"id": "nano", "vcpu": 1, "ram_gb": 1, "disk_gb": 10, "price_per_hour": 0.01}]
+    respx.get(f"{BASE_URL}/v1/sandboxes/catalog").respond(json=plans)
+    result = await Sandbox.acatalog(client=client)
+    assert result[0].id == "nano"
+
+
+@respx.mock
 async def test_async_context_manager(client):
     respx.get(f"{BASE_URL}/v1/sandboxes/{SB_ID}").respond(json=_info("running"))
     delete = respx.delete(f"{BASE_URL}/v1/sandboxes/{SB_ID}").respond(json={})


### PR DESCRIPTION
## Summary
- Adds `Sandbox.catalog()` / `Sandbox.acatalog()` to fetch available sandbox plans from `GET /v1/sandboxes/catalog`
- New `SandboxPlan` model exposes `id`, `vcpu`, `ram_gb`, `disk_gb`, `price_per_hour`, matching the backend's `SandboxPlanOut` (deepinfra/backend#3991)
- Updates README with a usage example

## Test plan
- [x] `pytest tests` (109 passed, incl. new sync/async catalog tests)
- [x] `mypy` / `ruff check .` clean